### PR TITLE
chore: replace gym with gymnasium and refresh dependencies

### DIFF
--- a/PokerRL/game/_/rl_env/base/PokerEnv.py
+++ b/PokerRL/game/_/rl_env/base/PokerEnv.py
@@ -5,7 +5,7 @@ import copy
 import time
 
 import numpy as np
-from gym import spaces
+from gymnasium import spaces
 
 from PokerRL.game.Poker import Poker
 from PokerRL.game.PokerEnvStateDictEnums import EnvDictIdxs, PlayerDictIdxs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
-gym==0.10.9
+gymnasium
 pycrayon==0.5
 psutil

--- a/requirements_dist.txt
+++ b/requirements_dist.txt
@@ -1,3 +1,3 @@
-ray==0.6.1
-redis==2.10.6
+ray
+redis
 boto3


### PR DESCRIPTION
## Summary
- replace old gym import with gymnasium
- refresh requirements to drop pinned versions

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement requests)
- `pytest` (fails: ModuleNotFoundError: No module named 'numpy')

------
https://chatgpt.com/codex/tasks/task_e_689632e89f508330a81ced36d9841ae6