### PR TITLE
Update ray wrapper for modern Ray API

### DIFF
--- a/PokerRL/rl/MaybeRay.py
+++ b/PokerRL/rl/MaybeRay.py
@@ -6,9 +6,8 @@ import torch
 # not being able to import ray is okay if you don't run distributed!
 try:
     import ray
-    import ray.utils
 except ModuleNotFoundError:
-    pass
+    ray = None
 
 
 class MaybeRay:
@@ -29,18 +28,14 @@ class MaybeRay:
         self.runs_cluster = runs_cluster
 
     # __________________________________________________ ray wrapper ___________________________________________________
-    def init_cluster(self, redis_address):
+    def init_cluster(self, address):
         assert self.runs_cluster
-        ray.init(
-            redis_address=redis_address,
-            redis_max_memory=min(10 ** 10, int(psutil.virtual_memory().total * 0.1)),
-            object_store_memory=min(2 * (10 ** 10), int(psutil.virtual_memory().total * 0.4)),
-        )
+        if self.runs_distributed:
+            ray.init(address=address)
 
     def init_local(self):
         if self.runs_distributed:
             ray.init(
-                redis_max_memory=min(10 ** 10, int(psutil.virtual_memory().total * 0.1)),
                 object_store_memory=min(2 * (10 ** 10), int(psutil.virtual_memory().total * 0.4)),
             )
 

--- a/PokerRL/rl/base_cls/TrainingProfileBase.py
+++ b/PokerRL/rl/base_cls/TrainingProfileBase.py
@@ -41,7 +41,7 @@ class TrainingProfileBase:
                  DEBUGGING=False,
 
                  # --- Only relevant if running distributed
-                 redis_head_adr=None,  # (str) IP under which the ray redis server can be reached
+                 ray_head_addr=None,  # (str) Address of the Ray head node
                  ):
         """
         Args:
@@ -66,8 +66,8 @@ class TrainingProfileBase:
             CLUSTER:                                requires "DISTRIBUTED==True".
                                                     If True, runs on many machines, if False, runs on local CPUs/GPUs.
             DEBUGGING (bool):                       Whether to use assert statements for debugging
-            redis_head_adr:                         Only applicable if "CLUSTER==True". IP address under which the ray
-                                                    head can be found.
+            ray_head_addr:                          Only applicable if "CLUSTER==True". Address where the Ray head
+                                                    can be found.
 
         """
 
@@ -84,12 +84,12 @@ class TrainingProfileBase:
         self.module_args = module_args
 
         if CLUSTER:
-            if redis_head_adr:
-                self.redis_head_adr = redis_head_adr
+            if ray_head_addr:
+                self.ray_head_addr = ray_head_addr
             else:
-                from ray import services
+                from ray.util import get_node_ip_address
 
-                self.redis_head_adr = services.get_node_ip_address() + ":6379"
+                self.ray_head_addr = get_node_ip_address() + ":6379"
         self.DISTRIBUTED = DISTRIBUTED or CLUSTER
         self.CLUSTER = CLUSTER
         self.DEBUGGING = DEBUGGING

--- a/PokerRL/rl/base_cls/workers/DriverBase.py
+++ b/PokerRL/rl/base_cls/workers/DriverBase.py
@@ -30,7 +30,7 @@ class DriverBase(WorkerBase):
         super().__init__(t_prof=t_prof)
 
         if self._t_prof.CLUSTER:
-            self._ray.init_cluster(redis_address=t_prof.redis_head_adr)
+            self._ray.init_cluster(address=t_prof.ray_head_addr)
         else:
             self._ray.init_local()
 

--- a/requirements_dist.txt
+++ b/requirements_dist.txt
@@ -1,3 +1,2 @@
-ray
-redis
+ray>=2.0.0
 boto3


### PR DESCRIPTION
## Summary
- modernize Ray wrapper for current Ray API
- replace redis-based initialization with address-based startup
- require modern Ray in distribution requirements

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68978d15ece48330a871156b3fff8910