### PR TITLE
Guard CUDA availability checks

### DIFF
--- a/PokerRL/eval/br/DistBRMaster.py
+++ b/PokerRL/eval/br/DistBRMaster.py
@@ -7,12 +7,11 @@ is not distributed.
 """
 
 import ray
-import torch
 
 from PokerRL.eval.br.LocalBRMaster import LocalBRMaster as LocalEvalBRMaster
 
 
-@ray.remote(num_cpus=1, num_gpus=1 if torch.cuda.is_available() else 0)
+@ray.remote(num_cpus=1)
 class DistBRMaster(LocalEvalBRMaster):
 
     def __init__(self, t_prof, chief_handle, eval_agent_cls):

--- a/PokerRL/eval/head_to_head/DistHead2HeadMaster.py
+++ b/PokerRL/eval/head_to_head/DistHead2HeadMaster.py
@@ -7,12 +7,11 @@ The H2H computation itself is not distributed.
 """
 
 import ray
-import torch
 
 from PokerRL.eval.head_to_head.LocalHead2HeadMaster import LocalHead2HeadMaster as LocalEvalHead2HeadMaster
 
 
-@ray.remote(num_cpus=1, num_gpus=1 if torch.cuda.is_available() else 0)
+@ray.remote(num_cpus=1)
 class DistHead2HeadMaster(LocalEvalHead2HeadMaster):
 
     def __init__(self, t_prof, chief_handle, eval_agent_cls):

--- a/PokerRL/eval/lbr/DistLBRWorker.py
+++ b/PokerRL/eval/lbr/DistLBRWorker.py
@@ -7,12 +7,11 @@ as you want to accelerate the LBR computation; the EvalLBRMaster will manage the
 """
 
 import ray
-import torch
 
 from PokerRL.eval.lbr.LocalLBRWorker import LocalLBRWorker as LocalEvalLBRWorker
 
 
-@ray.remote(num_cpus=1, num_gpus=1 if torch.cuda.is_available() else 0)
+@ray.remote(num_cpus=1)
 class DistLBRWorker(LocalEvalLBRWorker):
 
     def __init__(self, t_prof, chief_handle, eval_agent_cls):

--- a/PokerRL/eval/lbr/LocalLBRWorker.py
+++ b/PokerRL/eval/lbr/LocalLBRWorker.py
@@ -311,7 +311,11 @@ class LocalLBRWorker:
 class _AgentWrapper:
 
     def __init__(self, t_prof, lbr_args, eval_agent_cls):
-        self.USE_GPU = (t_prof.HAVE_GPU and lbr_args.use_gpu_for_batch_eval and torch.cuda.is_available())
+        try:
+            _cuda_ok = torch.cuda.is_available()
+        except Exception:
+            _cuda_ok = False
+        self.USE_GPU = (t_prof.HAVE_GPU and lbr_args.use_gpu_for_batch_eval and _cuda_ok)
 
         self.cpu_agent = eval_agent_cls(t_prof=t_prof, device=torch.device("cpu"))
 

--- a/PokerRL/rl/MaybeRay.py
+++ b/PokerRL/rl/MaybeRay.py
@@ -56,7 +56,13 @@ class MaybeRay:
 
     def create_worker(self, cls, *args):
         if self.runs_distributed:
-            return cls.remote(*args)
+            num_gpus = 0
+            try:
+                if torch.cuda.is_available():
+                    num_gpus = 1
+            except Exception:
+                num_gpus = 0
+            return cls.options(num_gpus=num_gpus).remote(*args)
         return cls(*args)
 
     def wait(self, _list, num_returns=None, timeout=None, return_not_ready=False):

--- a/PokerRL/rl/base_cls/TrainingProfileBase.py
+++ b/PokerRL/rl/base_cls/TrainingProfileBase.py
@@ -93,7 +93,10 @@ class TrainingProfileBase:
         self.DISTRIBUTED = DISTRIBUTED or CLUSTER
         self.CLUSTER = CLUSTER
         self.DEBUGGING = DEBUGGING
-        self.HAVE_GPU = torch.cuda.is_available()
+        try:
+            self.HAVE_GPU = torch.cuda.is_available()
+        except Exception:
+            self.HAVE_GPU = False
 
         self.n_seats = self.module_args["env"].n_seats
 


### PR DESCRIPTION
## Summary
- avoid calling `torch.cuda.is_available()` at import time in distributed evaluators
- safely check CUDA availability when creating Ray workers
- guard runtime GPU checks against CUDA-related errors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch'; ModuleNotFoundError: No module named 'scipy`*)

------
https://chatgpt.com/codex/tasks/task_e_68979ce30a248330a654c157ee187754