### PR TITLE
Add SciPy dependency for combinatorial utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 gymnasium
 psutil
 tensorboard
+scipy>=1.14.0


### PR DESCRIPTION
## Summary
- declare `scipy>=1.14.0` in base requirements so combinatorial helpers load correctly

## Testing
- `python -m pip install -r requirements.txt pytest`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python -m pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_6897a4a8492c83308323023f79b5f158