### PR TITLE
Track obs_size in env instead of shape

### DIFF
--- a/PokerRL/game/_/EnvWrapperBuilderBase.py
+++ b/PokerRL/game/_/EnvWrapperBuilderBase.py
@@ -87,7 +87,7 @@ class EnvWrapperBuilderBase:
         This is only run once, so it is ok, if it is not efficient to evaluate this.
         """
         _env = self.env_cls(env_args=self.env_args, lut_holder=self.lut_holder, is_evaluating=True)
-        return _env.observation_space.shape[0]
+        return _env.obs_size
 
     def _get_num_private_observation_features(self):
         """

--- a/PokerRL/game/_/rl_env/base/PokerEnv.py
+++ b/PokerRL/game/_/rl_env/base/PokerEnv.py
@@ -258,7 +258,6 @@ class PokerEnv:
             # __________________________  Return Complete _Observation Space  __________________________
             # Tuple (lots of spaces.Discrete and spaces.Box)
             _observation_space = spaces.Tuple(_table_space + _player_space + _board_space)
-            _observation_space.shape = [len(_observation_space.spaces)]
 
         else:
             # __________________________  Public Information About Game State  _________________________
@@ -327,7 +326,9 @@ class PokerEnv:
             # __________________________  Return Complete _Observation Space  __________________________
             # Tuple (lots of spaces.Discrete and spaces.Box)
             _observation_space = spaces.Tuple(_table_space + _player_space + _board_space)
-            _observation_space.shape = [len(_observation_space.spaces)]
+
+        # store the size of the observation vector separately as spaces.Tuple has no shape attribute
+        self.obs_size = len(_observation_space.spaces)
         return _observation_space, obs_idx_dict, obs_parts_idxs_dict
 
     def _init_from_args(self, env_args, is_evaluating):
@@ -1263,7 +1264,7 @@ class PokerEnv:
 
         """
         if is_terminal:
-            return np.zeros(shape=self.observation_space.shape, dtype=np.float32)  # terminal is all zero
+            return np.zeros(shape=(self.obs_size,), dtype=np.float32)  # terminal is all zero
         normalization_sum = float(sum([s.starting_stack_this_episode for s in self.seats])) / self.N_SEATS
         return np.array(self._get_table_state(normalization_sum=normalization_sum) \
                         + self._get_player_states_all_players(normalization_sum=normalization_sum) \

--- a/PokerRL/game/wrappers.py
+++ b/PokerRL/game/wrappers.py
@@ -50,7 +50,7 @@ class FlatLimitPokerEnvBuilder(_EnvWrapperBuilderBase):
 
     def _get_num_public_observation_features(self):
         _env = self.env_cls(env_args=self.env_args, lut_holder=self.lut_holder, is_evaluating=True)
-        return _env.observation_space.shape[0] + self.action_vector_size
+        return _env.obs_size + self.action_vector_size
 
     def get_vector_idx(self, round_, p_id, nth_action_this_round, action_idx):
         # *2 in line 3 stands for len([Poker.BET_RAISE, Poker.CHECK_CALL]). If action is fold, the obs is never going to


### PR DESCRIPTION
## Summary
- compute and expose `obs_size` in `PokerEnv` instead of hacking `observation_space.shape`
- update wrappers and env builders to use `obs_size`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(download too large; installation aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6897ad0e43388330b0857810429e9df7